### PR TITLE
Fix dependency differences with wolfram 0.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hubot-wolfram",
   "description": "Hubot script to query Wolfram Alpha.",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "main": "./src/wolfram",
   "repository": {
     "type": "git",
@@ -20,8 +20,6 @@
   },
   "homepage": "https://github.com/notpeter/hubot-wolfram",
   "dependencies": {
-    "request": "^2.1",
-    "libxmljs": "^0.8.1",
-    "wolfram": "^0.3.0"
+    "wolfram": "^0.3.2"
   }
 }


### PR DESCRIPTION
node-wolfram was updated to include dependencies that work on nodejs 0.12.x (https://github.com/strax/node-wolfram/pull/17), so there's no need to define them in this package. Additionally, the dependency listed for libxmljs conficts, and does not build on 0.12.x (defined as 0.8.1 here, and 0.14.0 in wolfram).

I've removed the duplicate and outdated dependencies and bumped up the minimum version for wolfram.
